### PR TITLE
add window-numbering-update to minibuffer-setup-hook

### DIFF
--- a/window-numbering.el
+++ b/window-numbering.el
@@ -204,6 +204,8 @@ windows to numbers."
           (window-numbering-install-mode-line)
           (add-hook 'window-configuration-change-hook
                     'window-numbering-update)
+          (add-hook 'minibuffer-setup-hook
+                    'window-numbering-update)
           (dolist (frame (frame-list))
             (select-frame frame)
             (window-numbering-update))))


### PR DESCRIPTION
Hi!

You have this variable `window-numbering-auto-assign-0-to-minibuffer`, which does exactly what I want. However, it wasn't working for me out-of-the-box, because `window-numbering-update` wasn't called when I entered the minibuffer. So, I needed to add `window-numbering-update` to `minibuffer-setup-hook` to make it working.

Do you think that's something that had to be done in the first place or am I missing something?