### PR TITLE
Fix bug when setting window-numbering-assign-func to a named function

### DIFF
--- a/window-numbering.el
+++ b/window-numbering.el
@@ -165,7 +165,7 @@ windows to numbers."
       (mapc `(lambda (window)
                (with-selected-window window
                  (with-current-buffer (window-buffer window)
-                   (let ((num (funcall ,window-numbering-assign-func)))
+                   (let ((num (funcall window-numbering-assign-func)))
                      (when num
                        (window-numbering-assign window num))))))
             windows))


### PR DESCRIPTION
We want quasi-quote to translate into:
`(funcall window-numbering-assign-func ...)`
But previous code was translated into:
`(funcall <value of window-numbering-assign-func> ..)`
Which caused an error.
Should fix #10

P.S. sorry about the unhelpful commit message, I edited the file via github (because it's such a small change) and didn't notice the automatic commit message that github gave it.
