### PR TITLE
Replace deprecated 'cl package by 'cl-lib

### DIFF
--- a/window-numbering.el
+++ b/window-numbering.el
@@ -4,9 +4,9 @@
 ;;
 ;; Author: Nikolaj Schumacher <bugs * nschum de>
 ;; Version: 1.1.2
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: faces, matching
 ;; URL: http://nschum.de/src/emacs/window-numbering-mode/
-;; Compatibility: GNU Emacs 22.x, GNU Emacs 23.x, GNU Emacs 24.x
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;
@@ -52,7 +52,7 @@
 ;;
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (push "^No window numbered .$" debug-ignored-errors)
 
@@ -119,7 +119,7 @@ If prefix ARG is given, delete the window instead of selecting it."
       (let ((window (aref windows i)))
         (unless window
           (push (% (1+ i) 10) left)))
-      (decf i))
+      (cl-decf i))
     left))
 
 (defvar window-numbering-windows nil


### PR DESCRIPTION
Beginning with emacs27, cl.el will be marked as obsolete.